### PR TITLE
Fix restaurant open hours data error

### DIFF
--- a/accessible_restaurant/templates/restaurants/detail.html
+++ b/accessible_restaurant/templates/restaurants/detail.html
@@ -324,9 +324,13 @@
                         {% else %}
                             <li class="no-bullets"><i class="icon fas fa-times-circle"></i>Closed</li>
                         {% endif %}
-                        {% for hour_data in hours %}
-                            <li>{{ hour_data.weekday }} &emsp; {{ hour_data.start }}-{{ hour_data.end }}</li>
-                        {% endfor %}
+                        {% if hours %}
+                            {% for hour_data in hours %}
+                                <li>{{ hour_data.weekday }} &emsp; {{ hour_data.start }}-{{ hour_data.end }}</li>
+                            {% endfor %}
+                        {% else %}
+                            <li>Open hours data not available</li>
+                        {% endif %}
                     </ul>
                     <h2>Contact Info</h2>
                     <ul class="alt">

--- a/accessible_restaurant/views.py
+++ b/accessible_restaurant/views.py
@@ -522,16 +522,19 @@ def restaurant_detail_view(request, business_id):
         hours = []
         is_open_now = False
         weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-        if restaurant_data["hours"]:
-            is_open_now = restaurant_data["hours"][0]["is_open_now"]
-            for day in restaurant_data["hours"][0]["open"]:
-                index = int(day["day"])
-                day["weekday"] = weekdays[index]
-                start = day["start"]
-                end = day["end"]
-                day["start"] = start[:2] + ":" + start[2:]
-                day["end"] = end[:2] + ":" + end[2:]
-                hours.append(day)
+        if "hours" in restaurant_data:
+            if restaurant_data["hours"]:
+                is_open_now = restaurant_data["hours"][0]["is_open_now"]
+                for day in restaurant_data["hours"][0]["open"]:
+                    index = int(day["day"])
+                    day["weekday"] = weekdays[index]
+                    start = day["start"]
+                    end = day["end"]
+                    day["start"] = start[:2] + ":" + start[2:]
+                    day["end"] = end[:2] + ":" + end[2:]
+                    hours.append(day)
+        else:
+            hours = None
 
         comment_form = CommentForm()
 


### PR DESCRIPTION
### Title:
Fix restaurant open hours data error

### Description:
For some restaurants, the open hours data on yelp is not available which causes error in restaurant detail page since it lists out open hours data by default.

### Types of Changes
- [ ] Env Setup
- [ ] Feature (non-breaking change which adds functionality)
- [x] Bug Fix (non-breaking change that fixes an issue)
- [ ] Breaking Change (feature/fix that causes existing features to not work as expected)
- [ ] Documentation